### PR TITLE
Remove the ability to click on calendar icon in Find a Suitable Lesson section of Timetable

### DIFF
--- a/frontend/src/app/modules/time-table/suitable-lesson/suitable-lesson.component.html
+++ b/frontend/src/app/modules/time-table/suitable-lesson/suitable-lesson.component.html
@@ -11,12 +11,9 @@
             </button>
 
             <div class="calendar-block">
-                <button class="button-icon" [matMenuTriggerFor]="appMenu">
-                    <img src="assets\calendar\calendar.svg">
-                </button>
-                <mat-menu #appMenu="matMenu">
-                    <mat-calendar #calendar (selectedChange)="select($event)"> </mat-calendar>
-                </mat-menu>
+                <div class="button-icon">
+                    <img src="assets\calendar\calendar.svg" />
+                </div>
 
                 {{ days[0].date.toLocaleDateString() }} - {{ days[6].date.toLocaleDateString() }}
             </div>
@@ -28,7 +25,11 @@
         </div>
 
         <div class="days">
-            <app-suitable-lesson-day *ngFor="let day of days" [meetingCount]="day.meetingsCount" [item]="day.date" (dateSelected)="onDateSelected($event)">
+            <app-suitable-lesson-day
+                *ngFor="let day of days"
+                [meetingCount]="day.meetingsCount"
+                [item]="day.date"
+                (dateSelected)="onDateSelected($event)">
             </app-suitable-lesson-day>
         </div>
     </div>

--- a/frontend/src/app/modules/time-table/suitable-lesson/suitable-lesson.component.sass
+++ b/frontend/src/app/modules/time-table/suitable-lesson/suitable-lesson.component.sass
@@ -38,6 +38,7 @@
 .button-week
     &:hover
         background-color: $turquoise-100
+        cursor: pointer
 
 .days
     display: grid
@@ -64,8 +65,6 @@
     justify-content: center
     align-items: center
     margin-right: 5px
-    &:hover
-        cursor: pointer
 
 .calendar-block
     display: flex


### PR DESCRIPTION
[Remove the ability to click on calendar icon in Find a Suitable Lesson section of Timetable](https://trello.com/c/E78qqNg2/90-remove-the-ability-to-click-on-calendar-icon-in-find-a-suitable-lesson-section-of-timetable)