### PR TITLE
the word 'meeting' is shown in the singular - 1 meeting

### DIFF
--- a/frontend/src/app/modules/time-table/suitable-lesson-day/suitable-lesson-day.component.html
+++ b/frontend/src/app/modules/time-table/suitable-lesson-day/suitable-lesson-day.component.html
@@ -6,6 +6,6 @@
     <div class="labels">
         <div *ngIf="isToday()" class="meetings today-label">today</div>
 
-        <div [ngClass]="{ 'meetings-grey': isBeforeToday() }" class="meetings">{{ meetingCount }} meetings</div>
+        <div [ngClass]="{ 'meetings-grey': isBeforeToday() }" class="meetings">{{ meetingCount }} {{ meetingNumber()}}</div>
     </div>
 </div>

--- a/frontend/src/app/modules/time-table/suitable-lesson-day/suitable-lesson-day.component.ts
+++ b/frontend/src/app/modules/time-table/suitable-lesson-day/suitable-lesson-day.component.ts
@@ -32,4 +32,6 @@ export class SuitableLessonDayComponent {
             this.dateSelected.emit(this.item);
         }
     }
+
+    meetingNumber = () => (this.meetingCount === 1 ? 'meeting' : 'meetings');
 }


### PR DESCRIPTION
[When the day on Timetable page has 1 meeting, the word 'meeting' is shown in the plural - 1 meetings](https://trello.com/c/ILBhSU8x/92-when-the-day-on-timetable-page-has-1-meeting-the-word-meeting-is-shown-in-the-plural-1-meetings)



![image](https://user-images.githubusercontent.com/122600284/228505091-2ba4e24f-7c4c-4a4e-9a19-5c62c0f03690.png)
