### PR TITLE
104 Bugfix topic icons display

### DIFF
--- a/frontend/src/app/shared/data/topics.ts
+++ b/frontend/src/app/shared/data/topics.ts
@@ -3,17 +3,17 @@ import { ITopic } from '@shared/models/ITopic';
 export const topics: ITopic[] = [
     {
         name: 'Architecture',
-        imgName: 'Classical Building.svg',
+        imgName: 'ClassicalBuilding.svg',
         selected: false,
     },
     {
         name: 'Art',
-        imgName: 'Artist Palette.svg',
+        imgName: 'ArtistPalette.svg',
         selected: false,
     },
     {
         name: 'Cars',
-        imgName: 'Racing Car.svg',
+        imgName: 'RacingCar.svg',
         selected: false,
     },
     {
@@ -28,7 +28,7 @@ export const topics: ITopic[] = [
     },
     {
         name: 'Dancing',
-        imgName: 'Woman Dancing.svg',
+        imgName: 'WomanDancing.svg',
         selected: false,
     },
     {
@@ -38,7 +38,7 @@ export const topics: ITopic[] = [
     },
     {
         name: 'Ecology',
-        imgName: 'Four Leaf Clover.svg',
+        imgName: 'FourLeafClover.svg',
         selected: false,
     },
     {
@@ -48,7 +48,7 @@ export const topics: ITopic[] = [
     },
     {
         name: 'History',
-        imgName: 'Crossed Swords.svg',
+        imgName: 'CrossedSwords.svg',
         selected: false,
     },
     {
@@ -63,12 +63,12 @@ export const topics: ITopic[] = [
     },
     {
         name: 'Pets',
-        imgName: 'Dog Face.svg',
+        imgName: 'DogFace.svg',
         selected: false,
     },
     {
         name: 'Philosophy',
-        imgName: 'Face With Monocle.svg',
+        imgName: 'FaceWithMonocle.svg',
         selected: false,
     },
     {


### PR DESCRIPTION
Some SVGs did not load correctly on topics selection page:
![image](https://user-images.githubusercontent.com/103057460/229040553-b863e78f-1371-4d77-b11c-f44be9598723.png)
I updated the page to load them correctly:
![image](https://user-images.githubusercontent.com/103057460/229040680-53c0552b-770f-4816-a6b9-24b99eac32d1.png)
