### PR TITLE
Update authpage input styles

### DIFF
--- a/frontend/src/app/modules/auth/auth-page/auth-page.component.sass
+++ b/frontend/src/app/modules/auth/auth-page/auth-page.component.sass
@@ -10,7 +10,7 @@
     display: flex
     justify-content: center
     align-items: center
-    
+
 
 @mixin icon
     width: 70%
@@ -41,7 +41,7 @@
 .router
     width: 50vw
     height: 100vh
-        
+
 
 .image-section
     height: 100%
@@ -143,14 +143,15 @@ h1
     .expand-icon
         position: absolute
         right: 1.5vw
-        top: 1.6vh
+        top: 50%
+        transform: translateY(-50%)
         color: $blue-200
         z-index: 4
     .placeholder
         position: absolute
         left: 1vw
-        top: 1.8vh
-        align-self: center
+        top: 50%
+        transform: translateY(-50%)
         color: $gray-200
         font-size: 14px
         z-index: 4
@@ -186,6 +187,7 @@ h1
     display: grid
     grid-template-columns: repeat(2, calc( 12vw - 7.5px ))
     gap: 15px
+    position: relative
 
 
 input
@@ -281,7 +283,7 @@ input
         align-items: center
         color: $gray-300
 
-    
+
 ::ng-deep.ng-select.ng-select-focused
     box-shadow: 0px 2px 6px $turquoise-100
     outline-color: $gray-100

--- a/frontend/src/app/modules/auth/auth-page/auth-page.component.sass
+++ b/frontend/src/app/modules/auth/auth-page/auth-page.component.sass
@@ -147,6 +147,7 @@ h1
         transform: translateY(-50%)
         color: $blue-200
         z-index: 4
+        cursor: pointer
     .placeholder
         position: absolute
         left: 1vw

--- a/frontend/src/app/shared/directives/password-visibility.directive.ts
+++ b/frontend/src/app/shared/directives/password-visibility.directive.ts
@@ -31,6 +31,7 @@ export class PasswordVisibilityDirective {
         span.style.top = '50%';
         span.style.transform = 'translateY(-50%)';
         span.style.zIndex = '10';
+        span.style.cursor = 'pointer';
         span.addEventListener('click', () => {
             this.toggle(span);
         });

--- a/frontend/src/app/shared/directives/password-visibility.directive.ts
+++ b/frontend/src/app/shared/directives/password-visibility.directive.ts
@@ -27,8 +27,9 @@ export class PasswordVisibilityDirective {
 
         span.innerHTML = '<img src="assets/password-visibility/closed-eye.svg" alt="closed-eye"/>';
         span.style.position = 'absolute';
-        span.style.right = '1.8vw';
-        span.style.top = '1.4vh';
+        span.style.right = '1.6vw';
+        span.style.top = '50%';
+        span.style.transform = 'translateY(-50%)';
         span.style.zIndex = '10';
         span.addEventListener('click', () => {
             this.toggle(span);


### PR DESCRIPTION
The expand and see password icons are now centered in their fields
![image](https://user-images.githubusercontent.com/103057460/229229655-6e56d7be-7265-471a-8802-da08f04f3cfa.png)
