### PR TITLE
fix padding between dialogue list and chat

### DIFF
--- a/frontend/src/app/modules/chat/chat-page/chat-page.component.sass
+++ b/frontend/src/app/modules/chat/chat-page/chat-page.component.sass
@@ -31,8 +31,7 @@ main
 aside
     width: 20%
     height: 80vh
-    padding: 57px
-    padding-bottom: 1px
+    padding: 57px 1% 0 57px
 
 .message-header
     display: flex


### PR DESCRIPTION
Reduced the space between the right part with the dialog and the left part where all the dialogs are displayed on the chat page


![image](https://user-images.githubusercontent.com/122600284/230150864-44553b6e-164b-4987-be39-a5827adffd13.png)
