### PR TITLE
Fix display time on lesson card with many tags

### DIFF
--- a/frontend/src/app/modules/lessons/lesson/lesson.component.sass
+++ b/frontend/src/app/modules/lessons/lesson/lesson.component.sass
@@ -191,7 +191,7 @@
     width: 100%
 
 .main-info
-    width: 100%
+    width: calc( 100% - 140px )
     display: flex
     flex-direction: column
 


### PR DESCRIPTION

With a large number of tags, the time was not displayed.
Fixed this point too
![image](https://user-images.githubusercontent.com/96182715/230402846-a933f464-13f8-4b2a-ae62-66815b5267f2.png)
